### PR TITLE
fix team ID/draft order discrepancy.

### DIFF
--- a/src/main/java/com/mayhew3/drafttower/client/AudioController.java
+++ b/src/main/java/com/mayhew3/drafttower/client/AudioController.java
@@ -57,12 +57,16 @@ public class AudioController extends Composite implements
     if (onDeck == null || onTheClock == null) {
       return;
     }
-    onDeck.getAudioElement().pause();
-    onDeck.getAudioElement().setCurrentTime(0);
-    onTheClock.getAudioElement().pause();
-    onTheClock.getAudioElement().setCurrentTime(0);
-    itsOver.getAudioElement().pause();
-    itsOver.getAudioElement().setCurrentTime(0);
+    try {
+      onDeck.getAudioElement().pause();
+      onDeck.getAudioElement().setCurrentTime(0);
+      onTheClock.getAudioElement().pause();
+      onTheClock.getAudioElement().setCurrentTime(0);
+      itsOver.getAudioElement().pause();
+      itsOver.getAudioElement().setCurrentTime(0);
+    } catch (Exception e) {
+      // Something happens here sometimes - clearing cache fixes it, so idk
+    }
 
     DraftStatus status = event.getStatus();
     if (status.isOver()) {

--- a/src/main/java/com/mayhew3/drafttower/client/CachingUnclaimedPlayerDataProvider.java
+++ b/src/main/java/com/mayhew3/drafttower/client/CachingUnclaimedPlayerDataProvider.java
@@ -123,7 +123,7 @@ public class CachingUnclaimedPlayerDataProvider extends UnclaimedPlayerDataProvi
   private final Map<PlayerDataSet, PlayerList> playersByDataSet = new HashMap<>();
   private final Map<PlayerDataSet, Runnable> requestCallbackByDataSet = new HashMap<>();
   private final OpenPositions openPositions;
-  private List<DraftPick> picks;
+  private List<DraftPick> picks = new ArrayList<>();
 
   @Inject
   public CachingUnclaimedPlayerDataProvider(BeanFactory beanFactory,

--- a/src/main/java/com/mayhew3/drafttower/server/CopyAllPlayerRanksServlet.java
+++ b/src/main/java/com/mayhew3/drafttower/server/CopyAllPlayerRanksServlet.java
@@ -25,7 +25,7 @@ public class CopyAllPlayerRanksServlet extends HttpServlet {
 
   @Inject
   public CopyAllPlayerRanksServlet(BeanFactory beanFactory,
-                                   PlayerDataSource playerDataSource) {
+      PlayerDataSource playerDataSource) {
     this.beanFactory = beanFactory;
     this.playerDataSource = playerDataSource;
   }

--- a/src/main/java/com/mayhew3/drafttower/server/GraphsServlet.java
+++ b/src/main/java/com/mayhew3/drafttower/server/GraphsServlet.java
@@ -26,12 +26,12 @@ public class GraphsServlet extends HttpServlet {
 
   private final BeanFactory beanFactory;
   private final PlayerDataSource playerDataSource;
-  private final Map<String, Integer> teamTokens;
+  private final Map<String, TeamDraftOrder> teamTokens;
 
   @Inject
   public GraphsServlet(BeanFactory beanFactory,
       PlayerDataSource playerDataSource,
-      @TeamTokens Map<String, Integer> teamTokens) {
+      @TeamTokens Map<String, TeamDraftOrder> teamTokens) {
     this.beanFactory = beanFactory;
     this.playerDataSource = playerDataSource;
     this.teamTokens = teamTokens;
@@ -44,12 +44,14 @@ public class GraphsServlet extends HttpServlet {
         AutoBeanCodex.decode(beanFactory, GetGraphsDataRequest.class, requestStr).as();
     GraphsData response;
     try {
-      response = playerDataSource.getGraphsData(teamTokens.get(request.getTeamToken()));
+      if (teamTokens.containsKey(request.getTeamToken())) {
+        response = playerDataSource.getGraphsData(teamTokens.get(request.getTeamToken()));
+        resp.getWriter().append(AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(response)).getPayload());
+      }
     } catch (SQLException e) {
       throw new ServletException(e);
     }
 
-    resp.getWriter().append(AutoBeanCodex.encode(AutoBeanUtils.getAutoBean(response)).getPayload());
     resp.setContentType("text/json");
   }
 }

--- a/src/main/java/com/mayhew3/drafttower/server/PlayerDataSource.java
+++ b/src/main/java/com/mayhew3/drafttower/server/PlayerDataSource.java
@@ -13,15 +13,15 @@ import java.util.Set;
 public interface PlayerDataSource {
   UnclaimedPlayerListResponse lookupUnclaimedPlayers(UnclaimedPlayerListRequest request) throws ServletException;
 
-  ListMultimap<Integer, Integer> getAllKeepers() throws ServletException;
+  ListMultimap<TeamDraftOrder, Integer> getAllKeepers() throws ServletException;
 
   void populateQueueEntry(QueueEntry queueEntry) throws SQLException;
 
   void populateDraftPick(DraftPick draftPick) throws SQLException;
 
-  long getBestPlayerId(PlayerDataSet wizardTable, Integer team, Set<Position> openPositions) throws SQLException;
+  long getBestPlayerId(PlayerDataSet wizardTable, TeamDraftOrder team, Set<Position> openPositions) throws SQLException;
 
-  void changePlayerRank(ChangePlayerRankRequest request);
+  void changePlayerRank(ChangePlayerRankRequest request) throws ServletException;
 
   void postDraftPick(DraftPick draftPick, DraftStatus status) throws SQLException;
 
@@ -31,5 +31,5 @@ public interface PlayerDataSource {
 
   void copyTableSpecToCustom(CopyAllPlayerRanksRequest request) throws SQLException;
 
-  GraphsData getGraphsData(int team) throws SQLException;
+  GraphsData getGraphsData(TeamDraftOrder teamDraftOrder) throws SQLException;
 }

--- a/src/main/java/com/mayhew3/drafttower/server/ServerTestSafeModule.java
+++ b/src/main/java/com/mayhew3/drafttower/server/ServerTestSafeModule.java
@@ -31,17 +31,17 @@ public class ServerTestSafeModule extends AbstractModule {
   }
 
   @Provides @Singleton @Keepers
-  public ListMultimap<Integer, Integer> getKeepers(PlayerDataSource playerDataSource) throws ServletException {
+  public ListMultimap<TeamDraftOrder, Integer> getKeepers(PlayerDataSource playerDataSource) throws ServletException {
     return playerDataSource.getAllKeepers();
   }
 
   @Provides @Singleton @Queues
-  public ListMultimap<Integer, QueueEntry> getQueues() {
+  public ListMultimap<TeamDraftOrder, QueueEntry> getQueues() {
     return ArrayListMultimap.create();
   }
 
   @Provides @Singleton @AutoPickWizards
-  public Map<Integer, PlayerDataSet> getAutoPickWizardTables(TeamDataSource teamDataSource) {
+  public Map<TeamDraftOrder, PlayerDataSet> getAutoPickWizardTables(TeamDataSource teamDataSource) {
     return teamDataSource.getAutoPickWizards();
   }
 
@@ -53,8 +53,8 @@ public class ServerTestSafeModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(DraftController.class).asEagerSingleton();
-    bind(new TypeLiteral<Map<String, Integer>>() {})
+    bind(new TypeLiteral<Map<String, TeamDraftOrder>>() {})
         .annotatedWith(TeamTokens.class)
-        .toInstance(new HashMap<String, Integer>());
+        .toInstance(new HashMap<String, TeamDraftOrder>());
   }
 }

--- a/src/main/java/com/mayhew3/drafttower/server/SetAutoPickWizardServlet.java
+++ b/src/main/java/com/mayhew3/drafttower/server/SetAutoPickWizardServlet.java
@@ -4,8 +4,8 @@ import com.google.common.io.CharStreams;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.autobean.shared.AutoBeanCodex;
-import com.mayhew3.drafttower.server.BindingAnnotations.TeamTokens;
 import com.mayhew3.drafttower.server.BindingAnnotations.AutoPickWizards;
+import com.mayhew3.drafttower.server.BindingAnnotations.TeamTokens;
 import com.mayhew3.drafttower.shared.BeanFactory;
 import com.mayhew3.drafttower.shared.PlayerDataSet;
 import com.mayhew3.drafttower.shared.SetWizardTableRequest;
@@ -25,14 +25,14 @@ public class SetAutoPickWizardServlet extends HttpServlet {
 
   private final BeanFactory beanFactory;
   private final TeamDataSource teamDataSource;
-  private final Map<String, Integer> teamTokens;
-  private final Map<Integer, PlayerDataSet> autoPickWizards;
+  private final Map<String, TeamDraftOrder> teamTokens;
+  private final Map<TeamDraftOrder, PlayerDataSet> autoPickWizards;
 
   @Inject
   public SetAutoPickWizardServlet(BeanFactory beanFactory,
-                                  TeamDataSource teamDataSource,
-                                  @TeamTokens Map<String, Integer> teamTokens,
-                                  @AutoPickWizards Map<Integer, PlayerDataSet> autoPickWizards) {
+      TeamDataSource teamDataSource,
+      @TeamTokens Map<String, TeamDraftOrder> teamTokens,
+      @AutoPickWizards Map<TeamDraftOrder, PlayerDataSet> autoPickWizards) {
     this.beanFactory = beanFactory;
     this.teamDataSource = teamDataSource;
     this.teamTokens = teamTokens;
@@ -44,10 +44,12 @@ public class SetAutoPickWizardServlet extends HttpServlet {
     String requestStr = CharStreams.toString(req.getReader());
     SetWizardTableRequest request =
         AutoBeanCodex.decode(beanFactory, SetWizardTableRequest.class, requestStr).as();
-    int teamID = teamTokens.get(request.getTeamToken());
-    PlayerDataSet dataSet = request.getPlayerDataSet();
-    autoPickWizards.put(teamID, dataSet);
+    if (teamTokens.containsKey(request.getTeamToken())) {
+      TeamDraftOrder teamDraftOrder = teamTokens.get(request.getTeamToken());
+      PlayerDataSet dataSet = request.getPlayerDataSet();
+      autoPickWizards.put(teamDraftOrder, dataSet);
 
-    teamDataSource.updateAutoPickWizard(teamID, dataSet);
+      teamDataSource.updateAutoPickWizard(teamDraftOrder, dataSet);
+    }
   }
 }

--- a/src/main/java/com/mayhew3/drafttower/server/TeamDataSource.java
+++ b/src/main/java/com/mayhew3/drafttower/server/TeamDataSource.java
@@ -5,19 +5,24 @@ import com.mayhew3.drafttower.shared.Team;
 
 import javax.servlet.ServletException;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Handles lookup and persistence of team-related data.
  */
 public interface TeamDataSource {
-  Integer getTeamNumber(String username, String password) throws ServletException;
+  TeamDraftOrder getTeamDraftOrder(String username, String password) throws ServletException;
 
-  boolean isCommissionerTeam(int team) throws SQLException;
+  boolean isCommissionerTeam(TeamDraftOrder teamDraftOrder) throws SQLException;
 
   Map<String, Team> getTeams() throws SQLException;
 
-  Map<Integer,PlayerDataSet> getAutoPickWizards();
+  HashMap<TeamDraftOrder, PlayerDataSet> getAutoPickWizards();
 
-  void updateAutoPickWizard(int teamID, PlayerDataSet wizardTable);
+  void updateAutoPickWizard(TeamDraftOrder teamDraftOrder, PlayerDataSet wizardTable);
+
+  TeamDraftOrder getDraftOrderByTeamId(TeamId teamID) throws SQLException;
+
+  TeamId getTeamIdByDraftOrder(TeamDraftOrder draftOrder) throws SQLException;
 }

--- a/src/main/java/com/mayhew3/drafttower/server/TeamDraftOrder.java
+++ b/src/main/java/com/mayhew3/drafttower/server/TeamDraftOrder.java
@@ -1,0 +1,23 @@
+package com.mayhew3.drafttower.server;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Wraps an integer representing a team's draft order, to ensure that we don't get it
+ * confused with the team's database ID.
+ */
+public class TeamDraftOrder extends AtomicReference<Integer> {
+  public TeamDraftOrder(Integer initialValue) {
+    super(initialValue);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TeamDraftOrder && ((TeamDraftOrder) obj).get().equals(get());
+  }
+
+  @Override
+  public int hashCode() {
+    return get();
+  }
+}

--- a/src/main/java/com/mayhew3/drafttower/server/TeamId.java
+++ b/src/main/java/com/mayhew3/drafttower/server/TeamId.java
@@ -1,0 +1,23 @@
+package com.mayhew3.drafttower.server;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Wraps an integer representing a team's database ID, to ensure that we don't get it
+ * confused with the team's draft order.
+ */
+public class TeamId extends AtomicReference<Integer> {
+  public TeamId(Integer initialValue) {
+    super(initialValue);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof TeamId && ((TeamId) obj).get().equals(get());
+  }
+
+  @Override
+  public int hashCode() {
+    return get();
+  }
+}

--- a/src/test/java/com/mayhew3/drafttower/server/DraftControllerTest.java
+++ b/src/test/java/com/mayhew3/drafttower/server/DraftControllerTest.java
@@ -23,8 +23,8 @@ public class DraftControllerTest {
 
   @Inject private DraftController draftController;
   @Inject private DraftStatus draftStatus;
-  @Inject @Keepers private ListMultimap<Integer, Integer> keepers;
-  @Inject @Queues private ListMultimap<Integer, QueueEntry> queues;
+  @Inject @Keepers private ListMultimap<TeamDraftOrder, Integer> keepers;
+  @Inject @Queues private ListMultimap<TeamDraftOrder, QueueEntry> queues;
   @Inject private BeanFactory beanFactory;
 
   @Test
@@ -36,7 +36,7 @@ public class DraftControllerTest {
         beanFactory.createDraftPick().as(),
         beanFactory.createDraftPick().as()));
     draftStatus.setCurrentTeam(5);
-    keepers.put(4, 0);
+    keepers.put(new TeamDraftOrder(4), 0);
     draftController.backOutLastPick();
     Assert.assertEquals(3, draftStatus.getCurrentTeam());
     Assert.assertEquals(2, draftStatus.getPicks().size());
@@ -54,7 +54,7 @@ public class DraftControllerTest {
     reset();
     QueueEntry queueEntry = beanFactory.createQueueEntry().as();
     queueEntry.setPlayerId(0);
-    queues.put(1, queueEntry);
+    queues.put(new TeamDraftOrder(1), queueEntry);
     draftController.timerExpired();
     Assert.assertFalse(draftStatus.getRobotTeams().contains(1));
   }

--- a/src/test/java/com/mayhew3/drafttower/server/TestPlayerDataSource.java
+++ b/src/test/java/com/mayhew3/drafttower/server/TestPlayerDataSource.java
@@ -18,7 +18,7 @@ public class TestPlayerDataSource implements PlayerDataSource {
   }
 
   @Override
-  public ListMultimap<Integer, Integer> getAllKeepers() throws ServletException {
+  public ListMultimap<TeamDraftOrder, Integer> getAllKeepers() throws ServletException {
     return ArrayListMultimap.create();
   }
 
@@ -31,7 +31,7 @@ public class TestPlayerDataSource implements PlayerDataSource {
   }
 
   @Override
-  public long getBestPlayerId(PlayerDataSet wizardTable, Integer team, Set<Position> openPositions) throws SQLException {
+  public long getBestPlayerId(PlayerDataSet wizardTable, TeamDraftOrder team, Set<Position> openPositions) throws SQLException {
     return 0;
   }
 
@@ -56,7 +56,7 @@ public class TestPlayerDataSource implements PlayerDataSource {
   }
 
   @Override
-  public GraphsData getGraphsData(int team) throws SQLException {
+  public GraphsData getGraphsData(TeamDraftOrder teamDraftOrder) throws SQLException {
     return null;
   }
 }

--- a/src/test/java/com/mayhew3/drafttower/server/TestTeamDataSource.java
+++ b/src/test/java/com/mayhew3/drafttower/server/TestTeamDataSource.java
@@ -13,12 +13,12 @@ import java.util.Map;
  */
 public class TestTeamDataSource implements TeamDataSource {
   @Override
-  public Integer getTeamNumber(String username, String password) throws ServletException {
+  public TeamDraftOrder getTeamDraftOrder(String username, String password) throws ServletException {
     return null;
   }
 
   @Override
-  public boolean isCommissionerTeam(int team) throws SQLException {
+  public boolean isCommissionerTeam(TeamDraftOrder teamDraftOrder) throws SQLException {
     return false;
   }
 
@@ -28,11 +28,21 @@ public class TestTeamDataSource implements TeamDataSource {
   }
 
   @Override
-  public Map<Integer, PlayerDataSet> getAutoPickWizards() {
+  public HashMap<TeamDraftOrder, PlayerDataSet> getAutoPickWizards() {
     return new HashMap<>();
   }
 
   @Override
-  public void updateAutoPickWizard(int teamID, PlayerDataSet wizardTable) {
+  public void updateAutoPickWizard(TeamDraftOrder teamDraftOrder, PlayerDataSet wizardTable) {
+  }
+
+  @Override
+  public TeamDraftOrder getDraftOrderByTeamId(TeamId teamID) throws SQLException {
+    return new TeamDraftOrder(teamID.get());
+  }
+
+  @Override
+  public TeamId getTeamIdByDraftOrder(TeamDraftOrder draftOrder) throws SQLException {
+    return new TeamId(draftOrder.get());
   }
 }


### PR DESCRIPTION
Last year the team IDs and draft orders were the same, so we were using the same integer for everything.  This year that's no longer the case.

Client-side everything is still expressed in terms of draft order.  Server-side we no longer deal with integers directly except when reading/writing to the database and serializing/deserializing to the wire; we introduce two separate wrapper classes for draft order and team ID so that we're explicit about which we're dealing with at all times.
