### PR TITLE
fixes stale clients DOSing other clients

### DIFF
--- a/.idea/artifacts/DraftTower_war_exploded.xml
+++ b/.idea/artifacts/DraftTower_war_exploded.xml
@@ -2,7 +2,6 @@
   <artifact type="exploded-war" name="DraftTower:war exploded">
     <output-path>$PROJECT_DIR$/target/draft-tower-1.0-SNAPSHOT</output-path>
     <root id="root">
-      <element id="javaee-facet-resources" facet="DraftTower/web/Web" />
       <element id="directory" name="WEB-INF">
         <element id="directory" name="classes">
           <element id="module-output" name="DraftTower" />
@@ -17,10 +16,10 @@
           <element id="library" level="project" name="Maven: com.google.code.findbugs:jsr305:1.3.9" />
           <element id="library" level="project" name="Maven: com.google.guava:guava:18.0" />
           <element id="library" level="project" name="Maven: com.google.gwt.inject:gin:2.1.2" />
+          <element id="library" level="project" name="Maven: com.google.inject.extensions:guice-assistedinject:3.0" />
           <element id="library" level="project" name="Maven: com.google.inject:guice:3.0" />
           <element id="library" level="project" name="Maven: javax.inject:javax.inject:1" />
           <element id="library" level="project" name="Maven: aopalliance:aopalliance:1.0" />
-          <element id="library" level="project" name="Maven: com.google.inject.extensions:guice-assistedinject:3.0" />
           <element id="library" level="project" name="Maven: com.google.inject.extensions:guice-servlet:3.0" />
           <element id="library" level="project" name="Maven: org.json:json:20090211" />
           <element id="library" level="project" name="Maven: mysql:mysql-connector-java:5.1.22" />
@@ -45,6 +44,10 @@
           <element id="library" level="project" name="Maven: org.apache.commons:commons-math3:3.3" />
         </element>
       </element>
+      <element id="directory" name="META-INF">
+        <element id="file-copy" path="$PROJECT_DIR$/target/draft-tower-1.0-SNAPSHOT/META-INF/MANIFEST.MF" />
+      </element>
+      <element id="javaee-facet-resources" facet="DraftTower/web/Web" />
       <element id="gwt-compiler-output" facet="DraftTower/gwt/GWT" />
     </root>
   </artifact>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -26,7 +26,7 @@
       <profile default="true" name="Default" enabled="false">
         <processorPath useClasspath="true" />
       </profile>
-      <profile default="false" name="Maven default annotation processors profile" enabled="true">
+      <profile default="false" name="Annotation profile for DraftTower" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
@@ -39,4 +39,3 @@
     </bytecodeTargetLevel>
   </component>
 </project>
-

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" hash="1680823172">
-    <data-source source="LOCAL" name="Data Source [2]" product="MySQL" version="5.0.41" jdbc-version="4.0" driver-name="MySQL-AB JDBC Driver" driver-version="mysql-connector-java-5.1.22 ( Revision: ${bzr.revision-id} )" uuid="f1a09926-ee36-4803-bddf-ae54b3e8bfdc">
-      <extra-name-characters>#@</extra-name-characters>
-      <identifier-quote-string>`</identifier-quote-string>
+    <data-source source="LOCAL" name="Data Source [2]" uuid="f1a09926-ee36-4803-bddf-ae54b3e8bfdc">
+      <driver-ref>mysql</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.jdbc.Driver</jdbc-driver>
       <jdbc-url>jdbc:mysql://localhost:3306/uncharted</jdbc-url>
-      <user-name>root</user-name>
       <libraries>
         <library>
           <url>jar://$MAVEN_REPOSITORY$/mysql/mysql-connector-java/5.1.22/mysql-connector-java-5.1.22.jar!/</url>
@@ -16,4 +14,3 @@
     </data-source>
   </component>
 </project>
-

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false">
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
+    <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>
-

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -42,10 +42,7 @@
       <option name="IGNORE_POINT_TO_ITSELF" value="false" />
       <option name="myAdditionalJavadocTags" value="" />
     </inspection_tool>
-    <inspection_tool class="MethodCanBeVariableArityMethod" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreByteAndShortArrayParameters" value="false" />
-      <option name="ignoreOverridingMethods" value="false" />
-    </inspection_tool>
+    <inspection_tool class="MethodCanBeVariableArityMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreObjectMethods" value="true" />
       <option name="ignoreAnonymousClassMethods" value="false" />

--- a/.idea/runConfigurations/GWT_tests.xml
+++ b/.idea/runConfigurations/GWT_tests.xml
@@ -34,6 +34,7 @@
     </RunnerSettings>
     <RunnerSettings RunnerId="Debug with VisualVM">
       <option name="DEBUG_PORT" value="" />
+      <option name="visualVMId" value="211125735394434" />
       <option name="TRANSPORT" value="0" />
       <option name="LOCAL" value="true" />
     </RunnerSettings>

--- a/.idea/runConfigurations/Jetty_8_1_8_v20121106.xml
+++ b/.idea/runConfigurations/Jetty_8_1_8_v20121106.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Jetty 8.1.8.v20121106" type="JettyConfiguration" factoryName="Local" APPLICATION_SERVER_NAME="Jetty 8.1.8.v20121106">
+  <configuration default="false" name="Jetty 8.1.8.v20121106" type="JettyConfiguration" factoryName="Local" APPLICATION_SERVER_NAME="Jetty 8.1.8.v20121106" ALTERNATIVE_JRE_ENABLED="false">
     <option name="OPEN_IN_BROWSER" value="false" />
     <option name="COMMON_VM_ARGUMENTS" value="-Djetty.port=8081 -Dws.port=8081 -Xmx512m" />
     <option name="SHOW_DIALOG_ON_UPDATE" value="false" />
@@ -95,6 +95,90 @@
             </JettyConfigFile>
           </list>
         </option>
+        <option name="myConfigFiles">
+          <list>
+            <JettyConfigFile>
+              <option name="active" value="true" />
+              <option name="path" value="etc/jetty-jmx.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-ajp.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-annotations.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-bio-ssl.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-bio.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-contexts.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-debug.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-deploy.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-fileserver.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-ipaccess.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-logging.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-monitor.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-overlay.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="active" value="true" />
+              <option name="path" value="etc/jetty-plus.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-policy.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-proxy.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-requestlog.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-rewrite.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-spdy-proxy.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-spdy.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-ssl.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-stats.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-testrealm.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-webapps.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty-xinetd.xml" />
+            </JettyConfigFile>
+            <JettyConfigFile>
+              <option name="path" value="etc/jetty.xml" />
+            </JettyConfigFile>
+          </list>
+        </option>
       </data>
     </server-settings>
     <predefined_log_file id="Jetty" enabled="true" />
@@ -106,6 +190,7 @@
     </RunnerSettings>
     <RunnerSettings RunnerId="Debug with VisualVM">
       <option name="DEBUG_PORT" value="" />
+      <option name="visualVMId" value="211125742046764" />
       <option name="TRANSPORT" value="0" />
       <option name="LOCAL" value="true" />
     </RunnerSettings>

--- a/DraftTower.iml
+++ b/DraftTower.iml
@@ -10,9 +10,9 @@
           <root url="file://$MODULE_DIR$/src/main/webapp" relative="/" />
         </webroots>
         <sourceRoots>
-          <root url="file://$MODULE_DIR$/target/generated-sources/gwt" />
           <root url="file://$MODULE_DIR$/src/main/java" />
           <root url="file://$MODULE_DIR$/src/main/resources" />
+          <root url="file://$MODULE_DIR$/target/generated-sources/gwt" />
         </sourceRoots>
       </configuration>
     </facet>
@@ -35,9 +35,9 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/gwt" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target/.generated" />
       <excludeFolder url="file://$MODULE_DIR$/target/draft-tower-1.0-SNAPSHOT" />
       <excludeFolder url="file://$MODULE_DIR$/target/maven-archiver" />
@@ -49,8 +49,6 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: com.google.gwt:gwt-servlet:2.7.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.gwt:gwt-user:2.7.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: javax.validation:validation-api:1.0.0.GA" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: javax.validation:validation-api:sources:1.0.0.GA" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.gwt:gwt-codeserver:2.7.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.gwt:gwt-dev:2.7.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm:5.0.3" level="project" />
@@ -58,6 +56,8 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-tree:5.0.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-commons:5.0.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: javax.validation:validation-api:1.0.0.GA" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: javax.validation:validation-api:sources:1.0.0.GA" level="project" />
     <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-websocket:8.1.8.v20121106" level="project" />
     <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:8.1.8.v20121106" level="project" />
     <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:8.1.8.v20121106" level="project" />
@@ -66,10 +66,10 @@
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:18.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.gwt.inject:gin:2.1.2" level="project" />
+    <orderEntry type="library" name="Maven: com.google.inject.extensions:guice-assistedinject:3.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.inject:guice:3.0" level="project" />
     <orderEntry type="library" name="Maven: javax.inject:javax.inject:1" level="project" />
     <orderEntry type="library" name="Maven: aopalliance:aopalliance:1.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.inject.extensions:guice-assistedinject:3.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.inject.extensions:guice-servlet:3.0" level="project" />
     <orderEntry type="library" name="Maven: org.json:json:20090211" level="project" />
     <orderEntry type="library" name="Maven: mysql:mysql-connector-java:5.1.22" level="project" />
@@ -101,4 +101,3 @@
     <orderEntry type="library" name="Maven: org.apache.commons:commons-math3:3.3" level="project" />
   </component>
 </module>
-

--- a/src/main/java/com/mayhew3/drafttower/client/DraftSocketHandler.java
+++ b/src/main/java/com/mayhew3/drafttower/client/DraftSocketHandler.java
@@ -86,7 +86,6 @@ public class DraftSocketHandler implements
 
   @Override
   public void onOpen() {
-    backoff = INITIAL_BACKOFF_MS;
     eventBus.fireEvent(new SocketConnectEvent());
     sendDraftCommand(IDENTIFY);
     for (int i = 0; i < CLOCK_SYNC_CYCLES; i++) {
@@ -111,6 +110,7 @@ public class DraftSocketHandler implements
     if (msg.startsWith(ServletEndpoints.CLOCK_SYNC)) {
       processClockSync(msg);
     } else {
+      backoff = INITIAL_BACKOFF_MS;
       draftStatus = AutoBeanCodex.decode(beanFactory, ClientDraftStatus.class, msg).as();
       long serialId = draftStatus.getDraftStatus().getSerialId();
       if (latestStatusSerialId < serialId) {

--- a/src/main/java/com/mayhew3/drafttower/server/DraftControllerImpl.java
+++ b/src/main/java/com/mayhew3/drafttower/server/DraftControllerImpl.java
@@ -101,11 +101,6 @@ public class DraftControllerImpl implements DraftController {
   }
 
   @Override
-  public void onClientConnected() {
-    socketServlet.sendMessage(getStatusEncoder());
-  }
-
-  @Override
   public void onDraftCommand(DraftCommand cmd) throws TerminateSocketException {
     try (Lock ignored = lock.lock()) {
       TeamDraftOrder teamDraftOrder = teamTokens.get(cmd.getTeamToken());
@@ -256,8 +251,8 @@ public class DraftControllerImpl implements DraftController {
     try (Lock ignored = lock.lock()) {
       if (teamTokens.containsKey(teamToken)) {
         status.getConnectedTeams().remove(teamTokens.get(teamToken).get());
+        socketServlet.sendMessage(getStatusEncoder());
       }
-      socketServlet.sendMessage(getStatusEncoder());
     }
   }
 

--- a/src/main/java/com/mayhew3/drafttower/server/DraftTowerWebSocket.java
+++ b/src/main/java/com/mayhew3/drafttower/server/DraftTowerWebSocket.java
@@ -7,8 +7,7 @@ import com.mayhew3.drafttower.shared.DraftCommand;
  * Interface for server side of websocket-based client-server communication.
  */
 public interface DraftTowerWebSocket {
-  public interface DraftCommandListener {
-    void onClientConnected();
+  interface DraftCommandListener {
     void onDraftCommand(DraftCommand cmd) throws TerminateSocketException;
     void onClientDisconnected(String playerToken);
   }

--- a/src/main/java/com/mayhew3/drafttower/server/DraftTowerWebSocketServlet.java
+++ b/src/main/java/com/mayhew3/drafttower/server/DraftTowerWebSocketServlet.java
@@ -39,9 +39,6 @@ public class DraftTowerWebSocketServlet extends WebSocketServlet implements Draf
       openSockets.add(this);
       this.connection = connection;
       connection.setMaxIdleTime(0);
-      for (DraftCommandListener listener : listeners) {
-        listener.onClientConnected();
-      }
     }
 
     public void sendMessage(String message) {

--- a/src/test/java/com/mayhew3/drafttower/loadclient/BadBackoffClient.java
+++ b/src/test/java/com/mayhew3/drafttower/loadclient/BadBackoffClient.java
@@ -1,0 +1,62 @@
+package com.mayhew3.drafttower.loadclient;
+
+import com.google.web.bindery.autobean.shared.AutoBean;
+import com.google.web.bindery.autobean.shared.AutoBeanCodex;
+import com.google.web.bindery.autobean.vm.AutoBeanFactorySource;
+import com.mayhew3.drafttower.shared.BeanFactory;
+import com.mayhew3.drafttower.shared.DraftCommand;
+import com.mayhew3.drafttower.shared.DraftCommand.Command;
+import org.eclipse.jetty.websocket.WebSocket.OnTextMessage;
+import org.eclipse.jetty.websocket.WebSocketClient;
+import org.eclipse.jetty.websocket.WebSocketClientFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Degenerate client which fails to back off when trying to reconnect.
+ */
+public class BadBackoffClient {
+  public static void main(String... args) throws Exception {
+    final BeanFactory beanFactory = AutoBeanFactorySource.create(BeanFactory.class);
+    WebSocketClientFactory factory = new WebSocketClientFactory();
+    factory.start();
+    final WebSocketClient client = factory.newWebSocketClient();
+    OnTextMessage websocket = new OnTextMessage() {
+      @Override
+      public void onOpen(Connection connection) {
+        System.out.println("onOpen");
+        AutoBean<DraftCommand> draftCommand = beanFactory.createDraftCommand();
+        draftCommand.as().setCommandType(Command.IDENTIFY);
+        draftCommand.as().setTeamToken("asdf");
+        String msg = AutoBeanCodex.encode(draftCommand).getPayload();
+        try {
+          connection.sendMessage(msg);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }
+
+      @Override
+      public void onClose(int closeCode, String message) {
+        System.out.println("onClose");
+        try {
+          connect(client, this);
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+
+      @Override
+      public void onMessage(String data) {
+        // handle incoming message
+      }
+    };
+    connect(client, websocket);
+  }
+
+  private static void connect(WebSocketClient client, OnTextMessage websocket) throws Exception {
+    client.open(new URI("ws://localhost:8081/draft-tower-1/socket"), websocket).get(5, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/com/mayhew3/drafttower/server/DraftControllerTest.java
+++ b/src/test/java/com/mayhew3/drafttower/server/DraftControllerTest.java
@@ -528,13 +528,6 @@ public class DraftControllerTest {
   }
 
   @Test
-  public void testOnClientConnectedSendsStatus() throws Exception {
-    DraftControllerImpl draftController = createDraftController();
-    draftController.onClientConnected();
-    Mockito.verify(socketServlet).sendMessage(Mockito.<Function<String,String>>any());
-  }
-
-  @Test
   public void testOnClientDisconnected() throws Exception {
     DraftControllerImpl draftController = createDraftController();
     draftStatus.getConnectedTeams().add(2);

--- a/src/test/java/com/mayhew3/drafttower/server/TestDraftTowerWebSocket.java
+++ b/src/test/java/com/mayhew3/drafttower/server/TestDraftTowerWebSocket.java
@@ -76,9 +76,6 @@ public class TestDraftTowerWebSocket implements DraftTowerWebSocket, Websocket {
   @Override
   public void open() {
     clientOpened = true;
-    for (DraftCommandListener serverListener : serverListeners) {
-      serverListener.onClientConnected();
-    }
     clientListener.onOpen();
   }
 


### PR DESCRIPTION
- reset client backoff on successful receipt of draft status, not on socket open
- don't send status on client connect (guest clients won't receive status until something else happens)
- don't send status on client disconnect unless we actually removed a connected team
- add test client which constantly reconnects and tries to identify with bad token

fixes issue #108